### PR TITLE
Refactorings across the GitHub workflow and Rust codebase

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,10 +60,11 @@ jobs:
         uses: actions/github-script@v6
         env:
           PREVIOUS_TAG: ${{ steps.get-previous.outputs.result }}
+          RELEASE_TAG: ${{ github.ref_name }}
         with:
           script: |
             const previousTag = process.env.PREVIOUS_TAG;
-            const releaseTag = `fusou-v${process.env.PACKAGE_VERSION}`;
+            const releaseTag = process.env.RELEASE_TAG;
 
             console.log(`Previous tag: ${previousTag}`);
             console.log(`Release tag: ${releaseTag}`);

--- a/.github/workflows/publish_with_version_tag.yml
+++ b/.github/workflows/publish_with_version_tag.yml
@@ -1,4 +1,4 @@
-name: "publish"
+name: "publish with version tag"
 
 on:
   workflow_dispatch:

--- a/packages/FUSOU-APP/src-tauri/build.rs
+++ b/packages/FUSOU-APP/src-tauri/build.rs
@@ -29,8 +29,7 @@ fn main() {
         if let Err(e) = writeln!(
             file,
             "export const env = {{ SUPABASE_URL: \"{}\", SUPABASE_ANON_KEY: \"{}\"}}",
-            supabase_url,
-            supabase_anon_key
+            supabase_url, supabase_anon_key
         ) {
             eprintln!("cannot write to file: {}", e);
         }

--- a/packages/FUSOU-APP/src-tauri/src/sequence/launch.rs
+++ b/packages/FUSOU-APP/src-tauri/src/sequence/launch.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     json_parser, util, wrap_proxy,
 };
-use tracing_unwrap::OptionExt;
+use tracing_unwrap::{OptionExt, ResultExt};
 
 pub async fn launch_with_options(
     window: tauri::Window,

--- a/packages/FUSOU-APP/src-tauri/src/wrap_proxy.rs
+++ b/packages/FUSOU-APP/src-tauri/src/wrap_proxy.rs
@@ -10,8 +10,11 @@ use crate::{
         get_pac_bidirectional_channel, get_proxy_bidirectional_channel,
         get_proxy_log_bidirectional_channel,
     },
-    cmd::native_cmd::{self, add_store, check_ca_installed},
+    cmd::native_cmd::{self, add_store},
 };
+
+#[cfg(target_os = "linux")]
+use crate::cmd::native_cmd::check_ca_installed;
 
 pub fn check_ca_and_install<R>(app: &tauri::AppHandle<R>)
 where


### PR DESCRIPTION
This pull request includes several improvements and refactorings across the GitHub workflow and Rust codebase. The most significant changes are a workflow update to support version tags during publishing, minor code cleanup in Rust files, and improved imports for better platform compatibility.

**GitHub Workflow Improvements:**

* The workflow file was renamed from `.github/workflows/publish.yml` to `.github/workflows/publish_with_version_tag.yml` and updated to use the version tag from the GitHub reference for releases, enabling more accurate tagging during publish operations. [[1]](diffhunk://#diff-49b11e3a6273531356c0a140274f987acc5a3ad65a609a5fa67a2598e1aefc1bL1-R1) [[2]](diffhunk://#diff-49b11e3a6273531356c0a140274f987acc5a3ad65a609a5fa67a2598e1aefc1bR63-R67)

**Rust Codebase Cleanup and Compatibility:**

* In `packages/FUSOU-APP/src-tauri/build.rs`, minor formatting was applied to the environment export statement for clarity.
* In `packages/FUSOU-APP/src-tauri/src/sequence/launch.rs`, the `ResultExt` trait from `tracing_unwrap` was added to imports, preparing for more robust error handling.
* In `packages/FUSOU-APP/src-tauri/src/wrap_proxy.rs`, the import of `check_ca_installed` was refactored to be conditional on Linux targets, improving cross-platform compatibility.