### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/packages/FUSOU-APP/src/utility/merge_object.tsx
+++ b/packages/FUSOU-APP/src/utility/merge_object.tsx
@@ -9,6 +9,10 @@ export function mergeObjects<T>(source: T, target: T): void {
   }
 
   Object.keys(source).forEach((key) => {
+    // Prevent prototype pollution
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      return;
+    }
     const sourceValue = (source as any)[key];
     const targetValue = (target as any)[key];
 


### PR DESCRIPTION
Potential fix for [https://github.com/tsukasa-u/FUSOU/security/code-scanning/5](https://github.com/tsukasa-u/FUSOU/security/code-scanning/5)

To fix prototype pollution vulnerabilities in this merge function:
- Add a check to skip copying or recursing into dangerous property names. Specifically, do not process the keys `__proto__`, `constructor`, and potentially `prototype`.
- The fix is best performed inside the loop at line 11, so that any key matching these names is skipped.
- You may prefer to use a well-known list, e.g., `['__proto__', 'constructor', 'prototype']`.
- There’s no need for external dependencies; a simple if-statement suffices.
- Only lines inside the file packages/FUSOU-APP/src/utility/merge_object.tsx need to be changed.
- Insert the guard immediately after line 11, so that the rest of the code does not assign to dangerous properties.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
