### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through a stack trace

### DIFF
--- a/packages/FUSOU-WEB/src/pages/api/auth/google/refresh_token.ts
+++ b/packages/FUSOU-WEB/src/pages/api/auth/google/refresh_token.ts
@@ -42,6 +42,9 @@ export const POST: APIRoute = async ({ request, cookies, redirect }) => {
         );
     } catch (error) {
         console.error('Error refreshing Google access token:', error);
-        return new Response(JSON.stringify(error), { status: 500 });
+        return new Response(
+            JSON.stringify({ error: "Failed to refresh access token" }),
+            { status: 500 }
+        );
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/tsukasa-u/FUSOU/security/code-scanning/4](https://github.com/tsukasa-u/FUSOU/security/code-scanning/4)

To fix the problem, we should avoid returning serialized error objects to the client. Instead, return a generic error message (such as `"Failed to refresh access token"`), and log the complete error server-side for developer debugging. 

Specifically:
- Change line 45 to return a response with a static message and a suitable status code (`500`).
- The server-side logging on line 44 (with `console.error`) should be kept, as developers will still be able to see the specifics.

No imports or other code changes are required in the snippet provided. All required changes are in the catch block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
