### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/packages/FUSOU-WEB/src/pages/api/fleet/snapshot.ts
+++ b/packages/FUSOU-WEB/src/pages/api/fleet/snapshot.ts
@@ -315,8 +315,9 @@ async function handleSnapshotUpload(
     }
     
   } catch (err: any) {
+    console.error("Supabase upsert failed", err);
     return new Response(
-      JSON.stringify({ error: "Supabase upsert failed", detail: String(err) }),
+      JSON.stringify({ error: "Supabase upsert failed", detail: "Internal server error" }),
       {
         status: 502,
         headers: { ...CORS_HEADERS, "content-type": "application/json" },


### PR DESCRIPTION
Potential fix for [https://github.com/tsukasa-u/FUSOU/security/code-scanning/7](https://github.com/tsukasa-u/FUSOU/security/code-scanning/7)

To fix this vulnerability, the code should avoid sending the actual error or its message (which might include stack traces or sensitive internal details) to the client. Instead, the response should return a generic error object for the user (e.g., `{ error: "Supabase upsert failed" }`), while the actual error (or its stack trace) should be logged on the server side for debugging purposes. 

**Steps:**  
- Change the `return` statement in the `catch` block at line 318–324 to only send a generic error in the `detail` field, such as "Internal server error".
- Before the return, log the actual error (using `console.error`) to keep diagnostic information on the server, not exposed to the client.
- No new imports are needed since `console.error` is already used elsewhere.
- Only the `catch (err: any)` block needs modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
