### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license_scanning.yml
+++ b/.github/workflows/license_scanning.yml
@@ -6,6 +6,9 @@ on:
     branches: [main, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/tsukasa-u/FUSOU/security/code-scanning/20](https://github.com/tsukasa-u/FUSOU/security/code-scanning/20)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required permissions to `GITHUB_TOKEN`. For this workflow, the steps are: checking out the repository and running the FOSSA action with an external API key. These operations only require read access to the repository contents; no GitHub‑side write operations (creating releases, writing checks, etc.) are visible in the snippet. Therefore, setting `permissions: contents: read` is appropriate.

The single best fix with minimal behavior change is to add a workflow‑level `permissions` section near the top of `.github/workflows/license_scanning.yml` (for example, right after the `on:` block). This applies to all jobs in the workflow and keeps the YAML structure simple. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the trigger (`on:`) configuration and the `env:` block. No additional methods, imports, or definitions are needed, since this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
